### PR TITLE
Initialize next first

### DIFF
--- a/src/Rotary_encoder.cpp
+++ b/src/Rotary_encoder.cpp
@@ -17,8 +17,8 @@
 Encoder* encoderHead = nullptr;
 
 Encoder::Encoder(int CLK_PIN, int DT_PIN)
-  : _CLK_PIN(CLK_PIN), _DT_PIN(DT_PIN), _scale(1), position(0),
-    lastCLK(LOW), lastDebounceTime(0), next(nullptr)
+  : next(nullptr), _CLK_PIN(CLK_PIN), _DT_PIN(DT_PIN), _scale(1), position(0),
+    lastCLK(LOW), lastDebounceTime(0)
 {
   // Add this encoder to the linked list
   next = encoderHead;


### PR DESCRIPTION
Move initialization of `next` pointer first in the initialization list to avoid warnings like:

<img width="1184" height="231" alt="image" src="https://github.com/user-attachments/assets/df4420f0-df42-45a7-877d-d041a8179de9" />
